### PR TITLE
Add methods to get price impact and estimated yield

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ To determine the estimates about a minting operation :
 ```javascript
 import { Transaction } from '@solana/web3.js';
 
-const perpPrice = await this.getCollateralPerpPriceUI(mango);
+const perpPrice = this.getCollateralPerpPriceUI(mango);
 
 // Minting
 // User wants to mint `collateralQuantity` (Collateral -> UXD)

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ if (!mintingPriceImpact) {
   throw new Error("mintingPriceImpact couldn't be determined.");
 }
 console.log("Minting price impact", mintingPriceImpact);
-const mintingEstimates = await depository.getMintingEstimates(
+const mintingEstimates = depository.getMintingEstimates(
   collateralQuantity,
   perpPrice,
   mintingPriceImpact,
@@ -208,7 +208,7 @@ if (!redeemingPriceImpact) {
 }
 console.log("Redeeming price impact", redeemingPriceImpact);
 
-const redeemingEstimates = await depository.getRedeemingEstimates(
+const redeemingEstimates = depository.getRedeemingEstimates(
   redeemableQuantity,
   perpPrice,
   mintingPriceImpact,

--- a/src/mango/depository.ts
+++ b/src/mango/depository.ts
@@ -378,13 +378,16 @@ export class MangoDepository {
     mango: Mango,
     quantity: number, // UI AMount
     side: OrderBookSide
-  ): Promise<number | undefined> {
+  ): Promise<number> {
     const nativeQuantity = uiToNative(quantity, this.collateralMintDecimals);
 
     const { loadBids, loadAsks } = await this.getPerpMarket(mango);
     const loadSideBook = side === OrderBookSide.Bid ? loadBids : loadAsks;
     const sideBook = await loadSideBook(mango.client.connection, false);
-
-    return sideBook.getImpactPriceUi(nativeQuantity);
+    const priceImpact = sideBook.getImpactPriceUi(nativeQuantity);
+    if (!priceImpact) {
+      throw new Error("PriceImpact couldn't be determined.");
+    }
+    return priceImpact;
   }
 }

--- a/src/mango/depository.ts
+++ b/src/mango/depository.ts
@@ -308,12 +308,12 @@ export class MangoDepository {
   // Estimated amount of Redeemable (UXD) that will be given for Minting (Mint or RebalancingLite when PnlPolarity is positive)
   // `collateralQuantity` : In Collateral UI units
   //  Output -> breakdown of estimated costs
-  public async getMintingEstimates(
+  public getMintingEstimates(
     collateralQuantity: number,
     perpPrice: number,
     mintingPriceImpact: number,
     mango: Mango
-  ): Promise<SwapEstimate> {
+  ): SwapEstimate {
     const takerFee = this.getCollateralPerpTakerFees(mango);
     const perfectAmount = collateralQuantity * perpPrice;
     const realAmount = collateralQuantity * mintingPriceImpact;
@@ -326,12 +326,12 @@ export class MangoDepository {
   // Estimated amount of Collateral (SOL/BTC/ETH) that will be given for Redeeming (Redeem or RebalancingLite when PnlPolarity is negative)
   // `collateralQuantity` : In UXD UI units
   //  Output -> Collateral UI Units, estimated
-  public async getRedeemingEstimates(
+  public getRedeemingEstimates(
     redeemableQuantity: number,
     perpPrice: number,
     priceImpact: number,
     mango: Mango
-  ): Promise<SwapEstimate> {
+  ): SwapEstimate {
     const takerFee = this.getCollateralPerpTakerFees(mango);
     const collateralQuantity = redeemableQuantity / perpPrice;
     const perfectAmount = collateralQuantity * perpPrice;
@@ -343,7 +343,7 @@ export class MangoDepository {
   }
 
   // Price impact for a minting operation (Mint or RebalancingLite when PnlPolarity is positive)
-  public async getMintingPriceImpact(
+  public getMintingPriceImpact(
     collateralQuantity: number, // UI units
     mango: Mango
   ): Promise<number | undefined> {


### PR DESCRIPTION
Derived from https://github.com/blockworks-foundation/mango-ui-v3/blob/eba6d0e1cacd1befc302b1d2cb714075a5d49353/components/trade_form/AdvancedTradeForm.tsx

This is for Mercurial in order to add our rebalancing routes, but that should be used by the front end too for the UI values.