### PR TITLE
[Protocol] Adding generic edit instructions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxd-protocol/uxd-client",
-  "version": "4.0.0-alpha.1",
+  "version": "4.0.0-alpha.3",
   "description": "JavaScript Client for the UXD Solana Program",
   "keywords": [
     "solana",

--- a/src/client.ts
+++ b/src/client.ts
@@ -54,33 +54,35 @@ export class UXDClient {
     controller: Controller,
     authority: PublicKey,
     uiFields: {
-      quoteMintAndRedeemSoftCap?: number;
+      quoteMintAndRedeemSoftCap?: {
+        value: number;
+        depository: MangoDepository;
+      };
       redeemableSoftCap?: number;
       redeemableGlobalSupplyCap?: number;
     },
     options: ConfirmOptions
   ) {
-    const uiToNativeOption = (value: number | undefined, decimals: number) => {
-      if (value !== undefined) {
-        return uiToNative(value, decimals);
-      } else {
-        return undefined;
-      }
-    };
+    const quoteMintAndRedeemSoftCap = uiFields.quoteMintAndRedeemSoftCap;
+    const redeemableSoftCap = uiFields.redeemableSoftCap;
+    const redeemableGlobalSupplyCap = uiFields.redeemableGlobalSupplyCap;
     return this.instruction.editController(
       {
-        quoteMintAndRedeemSoftCap: uiToNativeOption(
-          uiFields.quoteMintAndRedeemSoftCap,
-          controller.redeemableMintDecimals
-        ),
-        redeemableSoftCap: uiToNativeOption(
-          uiFields.redeemableSoftCap,
-          controller.redeemableMintDecimals // should this be: depository.quoteMintDecimals
-        ),
-        redeemableGlobalSupplyCap: uiToNativeOption(
-          uiFields.redeemableGlobalSupplyCap,
-          controller.redeemableMintDecimals
-        ),
+        quoteMintAndRedeemSoftCap: quoteMintAndRedeemSoftCap
+          ? uiToNative(
+              quoteMintAndRedeemSoftCap.value,
+              quoteMintAndRedeemSoftCap.depository.quoteMintDecimals // special case
+            )
+          : undefined,
+        redeemableSoftCap: redeemableSoftCap
+          ? uiToNative(redeemableSoftCap, controller.redeemableMintDecimals)
+          : undefined,
+        redeemableGlobalSupplyCap: redeemableGlobalSupplyCap
+          ? uiToNative(
+              redeemableGlobalSupplyCap,
+              controller.redeemableMintDecimals
+            )
+          : undefined,
       },
       {
         accounts: {
@@ -585,12 +587,12 @@ export class UXDClient {
   }
 
   public createEditMangoDepositoryInstruction(
-    fields: {
-      quoteMintAndRedeemFee: number;
-    },
     controller: Controller,
     depository: MangoDepository,
     authority: PublicKey,
+    fields: {
+      quoteMintAndRedeemFee: number;
+    },
     options: ConfirmOptions
   ): TransactionInstruction {
     return this.instruction.editMangoDepository(
@@ -623,5 +625,95 @@ export class UXDClient {
       },
       options: options,
     });
+  }
+
+  /**
+   * @deprecated
+   * for backward compatibility only
+   * please use createEditControllerInstruction instead
+   */
+  public createSetRedeemableGlobalSupplyCapInstruction(
+    controller: Controller,
+    authority: PublicKey,
+    redeemableGlobalSupplyCap: number,
+    options: ConfirmOptions
+  ): TransactionInstruction {
+    return this.createEditControllerInstruction(
+      controller,
+      authority,
+      {
+        redeemableGlobalSupplyCap: redeemableGlobalSupplyCap,
+      },
+      options
+    );
+  }
+
+  /**
+   * @deprecated
+   * for backward compatibility only
+   * please use createEditControllerInstruction instead
+   */
+  public createSetMangoDepositoriesRedeemableSoftCapInstruction(
+    controller: Controller,
+    authority: PublicKey,
+    redeemableSoftCap: number,
+    options: ConfirmOptions
+  ): TransactionInstruction {
+    return this.createEditControllerInstruction(
+      controller,
+      authority,
+      {
+        redeemableSoftCap: redeemableSoftCap,
+      },
+      options
+    );
+  }
+
+  /**
+   * @deprecated
+   * for backward compatibility only
+   * please use createEditMangoDepositoryInstruction instead
+   */
+  public createSetMangoDepositoryQuoteMintAndRedeemFeeInstruction(
+    quoteMintAndRedeemFee: number,
+    controller: Controller,
+    depository: MangoDepository,
+    authority: PublicKey,
+    options: ConfirmOptions
+  ): TransactionInstruction {
+    return this.createEditMangoDepositoryInstruction(
+      controller,
+      depository,
+      authority,
+      {
+        quoteMintAndRedeemFee: quoteMintAndRedeemFee,
+      },
+      options
+    );
+  }
+
+  /**
+   * @deprecated
+   * for backward compatibility only
+   * please use createEditMangoDepositoryInstruction instead
+   */
+  public createSetMangoDepositoryQuoteMintAndRedeemSoftCapInstruction(
+    quoteMintAndRedeemSoftCap: number,
+    controller: Controller,
+    depository: MangoDepository,
+    authority: PublicKey,
+    options: ConfirmOptions
+  ): TransactionInstruction {
+    return this.createEditControllerInstruction(
+      controller,
+      authority,
+      {
+        quoteMintAndRedeemSoftCap: {
+          value: quoteMintAndRedeemSoftCap,
+          depository: depository,
+        },
+      },
+      options
+    );
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -60,37 +60,37 @@ export class UXDClient {
     },
     options: ConfirmOptions
   ) {
-    const quoteMintAndRedeemSoftCap = uiFields.quoteMintAndRedeemSoftCap;
-    const redeemableSoftCap = uiFields.redeemableSoftCap;
-    const redeemableGlobalSupplyCap = uiFields.redeemableGlobalSupplyCap;
-    return this.instruction.editController(
-      {
-        quoteMintAndRedeemSoftCap: quoteMintAndRedeemSoftCap
+    const {
+      quoteMintAndRedeemSoftCap,
+      redeemableSoftCap,
+      redeemableGlobalSupplyCap,
+    } = uiFields;
+    const fields = {
+      quoteMintAndRedeemSoftCap: quoteMintAndRedeemSoftCap
+        ? uiToNative(
+            quoteMintAndRedeemSoftCap.value,
+            quoteMintAndRedeemSoftCap.depository.quoteMintDecimals // special case
+          )
+        : null,
+      redeemableSoftCap:
+        redeemableSoftCap !== undefined
+          ? uiToNative(redeemableSoftCap, controller.redeemableMintDecimals)
+          : null,
+      redeemableGlobalSupplyCap:
+        redeemableGlobalSupplyCap !== undefined
           ? uiToNative(
-              quoteMintAndRedeemSoftCap.value,
-              quoteMintAndRedeemSoftCap.depository.quoteMintDecimals // special case
+              redeemableGlobalSupplyCap,
+              controller.redeemableMintDecimals
             )
           : null,
-        redeemableSoftCap:
-          redeemableSoftCap !== undefined
-            ? uiToNative(redeemableSoftCap, controller.redeemableMintDecimals)
-            : null,
-        redeemableGlobalSupplyCap:
-          redeemableGlobalSupplyCap !== undefined
-            ? uiToNative(
-                redeemableGlobalSupplyCap,
-                controller.redeemableMintDecimals
-              )
-            : null,
+    };
+    return this.instruction.editController(fields, {
+      accounts: {
+        authority,
+        controller: controller.pda,
       },
-      {
-        accounts: {
-          authority,
-          controller: controller.pda,
-        },
-        options: options,
-      }
-    );
+      options: options,
+    });
   }
 
   public createRegisterMangoDepositoryInstruction(
@@ -588,20 +588,18 @@ export class UXDClient {
     },
     options: ConfirmOptions
   ): TransactionInstruction {
-    const quoteMintAndRedeemFee = uiFields.quoteMintAndRedeemFee;
-    return this.instruction.editMangoDepository(
-      {
-        quoteMintAndRedeemFee: quoteMintAndRedeemFee ?? null,
+    const { quoteMintAndRedeemFee } = uiFields;
+    const fields = {
+      quoteMintAndRedeemFee: quoteMintAndRedeemFee ?? null,
+    };
+    return this.instruction.editMangoDepository(fields, {
+      accounts: {
+        authority,
+        controller: controller.pda,
+        depository: depository.pda,
       },
-      {
-        accounts: {
-          authority,
-          controller: controller.pda,
-          depository: depository.pda,
-        },
-        options: options,
-      }
-    );
+      options: options,
+    });
   }
 
   public createDisableDepositoryRegularMintingInstruction(

--- a/src/client.ts
+++ b/src/client.ts
@@ -70,18 +70,18 @@ export class UXDClient {
               quoteMintAndRedeemSoftCap.value,
               quoteMintAndRedeemSoftCap.depository.quoteMintDecimals // special case
             )
-          : undefined,
+          : null,
         redeemableSoftCap:
           redeemableSoftCap !== undefined
             ? uiToNative(redeemableSoftCap, controller.redeemableMintDecimals)
-            : undefined,
+            : null,
         redeemableGlobalSupplyCap:
           redeemableGlobalSupplyCap !== undefined
             ? uiToNative(
                 redeemableGlobalSupplyCap,
                 controller.redeemableMintDecimals
               )
-            : undefined,
+            : null,
       },
       {
         accounts: {

--- a/src/client.ts
+++ b/src/client.ts
@@ -584,14 +584,14 @@ export class UXDClient {
     depository: MangoDepository,
     authority: PublicKey,
     uiFields: {
-      quoteMintAndRedeemFee: number;
+      quoteMintAndRedeemFee?: number;
     },
     options: ConfirmOptions
   ): TransactionInstruction {
     const quoteMintAndRedeemFee = uiFields.quoteMintAndRedeemFee;
     return this.instruction.editMangoDepository(
       {
-        quoteMintAndRedeemFee,
+        quoteMintAndRedeemFee: quoteMintAndRedeemFee ?? null,
       },
       {
         accounts: {

--- a/src/client.ts
+++ b/src/client.ts
@@ -68,13 +68,12 @@ export class UXDClient {
     const redeemableGlobalSupplyCap = uiFields.redeemableGlobalSupplyCap;
     return this.instruction.editController(
       {
-        quoteMintAndRedeemSoftCap:
-          quoteMintAndRedeemSoftCap !== undefined
-            ? uiToNative(
-                quoteMintAndRedeemSoftCap.value,
-                quoteMintAndRedeemSoftCap.depository.quoteMintDecimals // special case
-              )
-            : undefined,
+        quoteMintAndRedeemSoftCap: quoteMintAndRedeemSoftCap
+          ? uiToNative(
+              quoteMintAndRedeemSoftCap.value,
+              quoteMintAndRedeemSoftCap.depository.quoteMintDecimals // special case
+            )
+          : undefined,
         redeemableSoftCap:
           redeemableSoftCap !== undefined
             ? uiToNative(redeemableSoftCap, controller.redeemableMintDecimals)
@@ -604,7 +603,7 @@ export class UXDClient {
       },
       {
         accounts: {
-          authority: authority,
+          authority,
           controller: controller.pda,
           depository: depository.pda,
         },
@@ -648,7 +647,7 @@ export class UXDClient {
       {
         quoteMintAndRedeemSoftCap: {
           value: quoteMintAndRedeemSoftCap,
-          depository: depository,
+          depository,
         },
       },
       options
@@ -670,7 +669,7 @@ export class UXDClient {
       controller,
       authority,
       {
-        redeemableGlobalSupplyCap: redeemableGlobalSupplyCap,
+        redeemableGlobalSupplyCap,
       },
       options
     );
@@ -691,7 +690,7 @@ export class UXDClient {
       controller,
       authority,
       {
-        redeemableSoftCap: redeemableSoftCap,
+        redeemableSoftCap,
       },
       options
     );
@@ -714,7 +713,7 @@ export class UXDClient {
       depository,
       authority,
       {
-        quoteMintAndRedeemFee: quoteMintAndRedeemFee,
+        quoteMintAndRedeemFee,
       },
       options
     );

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,8 +1,6 @@
 import { uiToNative, I80F48 } from '@blockworks-foundation/mango-client';
 import { BN, InstructionNamespace } from '@project-serum/anchor';
-import {
-  TOKEN_PROGRAM_ID,
-} from '@solana/spl-token';
+import { TOKEN_PROGRAM_ID } from '@solana/spl-token';
 import {
   SystemProgram,
   SYSVAR_RENT_PUBKEY,

--- a/src/client.ts
+++ b/src/client.ts
@@ -68,21 +68,24 @@ export class UXDClient {
     const redeemableGlobalSupplyCap = uiFields.redeemableGlobalSupplyCap;
     return this.instruction.editController(
       {
-        quoteMintAndRedeemSoftCap: quoteMintAndRedeemSoftCap
-          ? uiToNative(
-              quoteMintAndRedeemSoftCap.value,
-              quoteMintAndRedeemSoftCap.depository.quoteMintDecimals // special case
-            )
-          : undefined,
-        redeemableSoftCap: redeemableSoftCap
-          ? uiToNative(redeemableSoftCap, controller.redeemableMintDecimals)
-          : undefined,
-        redeemableGlobalSupplyCap: redeemableGlobalSupplyCap
-          ? uiToNative(
-              redeemableGlobalSupplyCap,
-              controller.redeemableMintDecimals
-            )
-          : undefined,
+        quoteMintAndRedeemSoftCap:
+          quoteMintAndRedeemSoftCap !== undefined
+            ? uiToNative(
+                quoteMintAndRedeemSoftCap.value,
+                quoteMintAndRedeemSoftCap.depository.quoteMintDecimals // special case
+              )
+            : undefined,
+        redeemableSoftCap:
+          redeemableSoftCap !== undefined
+            ? uiToNative(redeemableSoftCap, controller.redeemableMintDecimals)
+            : undefined,
+        redeemableGlobalSupplyCap:
+          redeemableGlobalSupplyCap !== undefined
+            ? uiToNative(
+                redeemableGlobalSupplyCap,
+                controller.redeemableMintDecimals
+              )
+            : undefined,
       },
       {
         accounts: {
@@ -632,6 +635,31 @@ export class UXDClient {
    * for backward compatibility only
    * please use createEditControllerInstruction instead
    */
+  public createSetMangoDepositoryQuoteMintAndRedeemSoftCapInstruction(
+    quoteMintAndRedeemSoftCap: number,
+    controller: Controller,
+    depository: MangoDepository,
+    authority: PublicKey,
+    options: ConfirmOptions
+  ): TransactionInstruction {
+    return this.createEditControllerInstruction(
+      controller,
+      authority,
+      {
+        quoteMintAndRedeemSoftCap: {
+          value: quoteMintAndRedeemSoftCap,
+          depository: depository,
+        },
+      },
+      options
+    );
+  }
+
+  /**
+   * @deprecated
+   * for backward compatibility only
+   * please use createEditControllerInstruction instead
+   */
   public createSetRedeemableGlobalSupplyCapInstruction(
     controller: Controller,
     authority: PublicKey,
@@ -687,31 +715,6 @@ export class UXDClient {
       authority,
       {
         quoteMintAndRedeemFee: quoteMintAndRedeemFee,
-      },
-      options
-    );
-  }
-
-  /**
-   * @deprecated
-   * for backward compatibility only
-   * please use createEditMangoDepositoryInstruction instead
-   */
-  public createSetMangoDepositoryQuoteMintAndRedeemSoftCapInstruction(
-    quoteMintAndRedeemSoftCap: number,
-    controller: Controller,
-    depository: MangoDepository,
-    authority: PublicKey,
-    options: ConfirmOptions
-  ): TransactionInstruction {
-    return this.createEditControllerInstruction(
-      controller,
-      authority,
-      {
-        quoteMintAndRedeemSoftCap: {
-          value: quoteMintAndRedeemSoftCap,
-          depository: depository,
-        },
       },
       options
     );

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,6 @@
 import { uiToNative, I80F48 } from '@blockworks-foundation/mango-client';
 import { BN, InstructionNamespace } from '@project-serum/anchor';
 import {
-  ASSOCIATED_TOKEN_PROGRAM_ID,
   TOKEN_PROGRAM_ID,
 } from '@solana/spl-token';
 import {
@@ -512,7 +511,6 @@ export class UXDClient {
         //
         systemProgram: SystemProgram.programId,
         tokenProgram: TOKEN_PROGRAM_ID,
-        associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
         mangoProgram: mango.programId,
         //
         rent: SYSVAR_RENT_PUBKEY,
@@ -576,7 +574,6 @@ export class UXDClient {
           //
           systemProgram: SystemProgram.programId,
           tokenProgram: TOKEN_PROGRAM_ID,
-          associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
           mangoProgram: mango.programId,
           //
           rent: SYSVAR_RENT_PUBKEY,

--- a/src/client.ts
+++ b/src/client.ts
@@ -575,14 +575,15 @@ export class UXDClient {
     controller: Controller,
     depository: MangoDepository,
     authority: PublicKey,
-    fields: {
+    uiFields: {
       quoteMintAndRedeemFee: number;
     },
     options: ConfirmOptions
   ): TransactionInstruction {
+    const quoteMintAndRedeemFee = uiFields.quoteMintAndRedeemFee;
     return this.instruction.editMangoDepository(
       {
-        quoteMintAndRedeemFee: fields.quoteMintAndRedeemFee,
+        quoteMintAndRedeemFee,
       },
       {
         accounts: {

--- a/src/idl.ts
+++ b/src/idl.ts
@@ -51,7 +51,7 @@ export const IDL: Idl = {
       ],
     },
     {
-      name: 'setRedeemableGlobalSupplyCap',
+      name: 'editController',
       accounts: [
         {
           name: 'authority',
@@ -66,50 +66,10 @@ export const IDL: Idl = {
       ],
       args: [
         {
-          name: 'redeemableGlobalSupplyCap',
-          type: 'u128',
-        },
-      ],
-    },
-    {
-      name: 'setMangoDepositoriesRedeemableSoftCap',
-      accounts: [
-        {
-          name: 'authority',
-          isMut: false,
-          isSigner: true,
-        },
-        {
-          name: 'controller',
-          isMut: true,
-          isSigner: false,
-        },
-      ],
-      args: [
-        {
-          name: 'redeemableSoftCap',
-          type: 'u64',
-        },
-      ],
-    },
-    {
-      name: 'setMangoDepositoryQuoteMintAndRedeemSoftCap',
-      accounts: [
-        {
-          name: 'authority',
-          isMut: false,
-          isSigner: true,
-        },
-        {
-          name: 'controller',
-          isMut: true,
-          isSigner: false,
-        },
-      ],
-      args: [
-        {
-          name: 'quoteMintAndRedeemSoftCap',
-          type: 'u64',
+          name: 'fields',
+          type: {
+            defined: 'EditControllerFields',
+          },
         },
       ],
     },
@@ -940,7 +900,7 @@ export const IDL: Idl = {
       ],
     },
     {
-      name: 'setMangoDepositoryQuoteMintAndRedeemFee',
+      name: 'editMangoDepository',
       accounts: [
         {
           name: 'authority',
@@ -960,8 +920,10 @@ export const IDL: Idl = {
       ],
       args: [
         {
-          name: 'quoteFee',
-          type: 'u8',
+          name: 'fields',
+          type: {
+            defined: 'EditMangoDepositoryFields',
+          },
         },
       ],
     },
@@ -994,7 +956,7 @@ export const IDL: Idl = {
   ],
   accounts: [
     {
-      name: 'controller',
+      name: 'Controller',
       type: {
         kind: 'struct',
         fields: [
@@ -1052,7 +1014,7 @@ export const IDL: Idl = {
       },
     },
     {
-      name: 'mangoDepository',
+      name: 'MangoDepository',
       type: {
         kind: 'struct',
         fields: [
@@ -1151,6 +1113,46 @@ export const IDL: Idl = {
     },
   ],
   types: [
+    {
+      name: 'EditControllerFields',
+      type: {
+        kind: 'struct',
+        fields: [
+          {
+            name: 'quoteMintAndRedeemSoftCap',
+            type: {
+              option: 'u64',
+            },
+          },
+          {
+            name: 'redeemableSoftCap',
+            type: {
+              option: 'u64',
+            },
+          },
+          {
+            name: 'redeemableGlobalSupplyCap',
+            type: {
+              option: 'u128',
+            },
+          },
+        ],
+      },
+    },
+    {
+      name: 'EditMangoDepositoryFields',
+      type: {
+        kind: 'struct',
+        fields: [
+          {
+            name: 'quoteMintAndRedeemFee',
+            type: {
+              option: 'u8',
+            },
+          },
+        ],
+      },
+    },
     {
       name: 'PnlPolarity',
       type: {

--- a/src/idl.ts
+++ b/src/idl.ts
@@ -122,11 +122,6 @@ export const IDL: Idl = {
           isSigner: false,
         },
         {
-          name: 'tokenProgram',
-          isMut: false,
-          isSigner: false,
-        },
-        {
           name: 'mangoProgram',
           isMut: false,
           isSigner: false,
@@ -190,11 +185,6 @@ export const IDL: Idl = {
         {
           name: 'mangoVault',
           isMut: true,
-          isSigner: false,
-        },
-        {
-          name: 'tokenProgram',
-          isMut: false,
           isSigner: false,
         },
         {
@@ -266,16 +256,6 @@ export const IDL: Idl = {
         {
           name: 'mangoVault',
           isMut: true,
-          isSigner: false,
-        },
-        {
-          name: 'systemProgram',
-          isMut: false,
-          isSigner: false,
-        },
-        {
-          name: 'tokenProgram',
-          isMut: false,
           isSigner: false,
         },
         {
@@ -405,11 +385,6 @@ export const IDL: Idl = {
           isSigner: false,
         },
         {
-          name: 'systemProgram',
-          isMut: false,
-          isSigner: false,
-        },
-        {
           name: 'tokenProgram',
           isMut: false,
           isSigner: false,
@@ -523,11 +498,6 @@ export const IDL: Idl = {
         {
           name: 'mangoEventQueue',
           isMut: true,
-          isSigner: false,
-        },
-        {
-          name: 'systemProgram',
-          isMut: false,
           isSigner: false,
         },
         {
@@ -651,11 +621,6 @@ export const IDL: Idl = {
           isSigner: false,
         },
         {
-          name: 'systemProgram',
-          isMut: false,
-          isSigner: false,
-        },
-        {
           name: 'tokenProgram',
           isMut: false,
           isSigner: false,
@@ -761,17 +726,7 @@ export const IDL: Idl = {
           isSigner: false,
         },
         {
-          name: 'associatedTokenProgram',
-          isMut: false,
-          isSigner: false,
-        },
-        {
           name: 'mangoProgram',
-          isMut: false,
-          isSigner: false,
-        },
-        {
-          name: 'rent',
           isMut: false,
           isSigner: false,
         },
@@ -867,27 +822,12 @@ export const IDL: Idl = {
           isSigner: false,
         },
         {
-          name: 'systemProgram',
-          isMut: false,
-          isSigner: false,
-        },
-        {
           name: 'tokenProgram',
           isMut: false,
           isSigner: false,
         },
         {
-          name: 'associatedTokenProgram',
-          isMut: false,
-          isSigner: false,
-        },
-        {
           name: 'mangoProgram',
-          isMut: false,
-          isSigner: false,
-        },
-        {
-          name: 'rent',
           isMut: false,
           isSigner: false,
         },
@@ -1470,7 +1410,7 @@ export const IDL: Idl = {
       ],
     },
     {
-      name: 'RedeemFromDepositoryEvent',
+      name: 'RedeemFromMangoDepositoryEvent',
       fields: [
         {
           name: 'version',
@@ -1582,6 +1522,146 @@ export const IDL: Idl = {
         {
           name: 'feeDelta',
           type: 'i64',
+          index: false,
+        },
+      ],
+    },
+    {
+      name: 'SetMangoDepositoryQuoteMintAndRedeemSoftCapEvent',
+      fields: [
+        {
+          name: 'version',
+          type: 'u8',
+          index: false,
+        },
+        {
+          name: 'controller',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'quoteMintAndRedeemSoftCap',
+          type: 'u64',
+          index: false,
+        },
+      ],
+    },
+    {
+      name: 'SetMangoDepositoryQuoteMintAndRedeemFeeEvent',
+      fields: [
+        {
+          name: 'version',
+          type: 'u8',
+          index: false,
+        },
+        {
+          name: 'controller',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'depository',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'quoteMintAndRedeemFee',
+          type: 'u8',
+          index: false,
+        },
+      ],
+    },
+    {
+      name: 'QuoteRedeemFromMangoDepositoryEvent',
+      fields: [
+        {
+          name: 'version',
+          type: 'u8',
+          index: false,
+        },
+        {
+          name: 'controller',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'depository',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'user',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'quoteRedeemableAmount',
+          type: 'u64',
+          index: false,
+        },
+        {
+          name: 'quoteRedeemFee',
+          type: 'u64',
+          index: false,
+        },
+      ],
+    },
+    {
+      name: 'QuoteMintWithMangoDepositoryEvent',
+      fields: [
+        {
+          name: 'version',
+          type: 'u8',
+          index: false,
+        },
+        {
+          name: 'controller',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'depository',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'user',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'quoteMintAmount',
+          type: 'u64',
+          index: false,
+        },
+        {
+          name: 'quoteMintFee',
+          type: 'u64',
+          index: false,
+        },
+      ],
+    },
+    {
+      name: 'DisableDepositoryRegularMintingEvent',
+      fields: [
+        {
+          name: 'version',
+          type: 'u8',
+          index: false,
+        },
+        {
+          name: 'controller',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'depository',
+          type: 'publicKey',
+          index: false,
+        },
+        {
+          name: 'regularMintingDisabled',
+          type: 'bool',
           index: false,
         },
       ],

--- a/src/idl.ts
+++ b/src/idl.ts
@@ -956,7 +956,7 @@ export const IDL: Idl = {
   ],
   accounts: [
     {
-      name: 'Controller',
+      name: 'controller',
       type: {
         kind: 'struct',
         fields: [
@@ -1014,7 +1014,7 @@ export const IDL: Idl = {
       },
     },
     {
-      name: 'MangoDepository',
+      name: 'mangoDepository',
       type: {
         kind: 'struct',
         fields: [

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -58,7 +58,3 @@ export enum PnLPolarity {
   Positive = `Positive`,
   Negative = `Negative`,
 }
-
-export interface EditMangoDepositoryFields {
-  quoteMintAndRedeemFee?: BN;
-}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -58,3 +58,7 @@ export enum PnLPolarity {
   Positive = `Positive`,
   Negative = `Negative`,
 }
+
+export interface EditMangoDepositoryFields {
+  quoteMintAndRedeemFee?: BN;
+}


### PR DESCRIPTION
This PR require a multi-repository change set:
- uxd-client for javascript public API: https://github.com/UXDProtocol/uxd-client/pull/21
- uxd-program for smart contract update: https://github.com/UXDProtocol/uxd-program/pull/182

In this PR I update the IDL based on recent change on the uxd-program, and also ensure backward compatibility for all client endpoints

Changelog:

```
Introduce new permissioned instructions:
  - "editController", edit arbitrary fields on the UXD controller
  - "editMangoDepository", edit arbitrary fields on the UXD mango single-colateral repository
In order to deprecate the permissioned instructions:
  - "setMangoDepositoryQuoteMintAndRedeemFee"
  - "setMangoDepositoriesRedeemableSoftCap"
  - "setRedeemableGlobalSupplyCap"
  - "setMangoDepositoryQuoteMintAndRedeemSoftCap"
```