### PR TITLE
[Rebalancing] [Part4] Compute depositories target weights IX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uxd-protocol/uxd-client",
-  "version": "7.1.0-depository-weights",
+  "version": "7.1.1-depository-weights",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uxd-protocol/uxd-client",
-      "version": "7.1.0-depository-weights",
+      "version": "7.1.1-depository-weights",
       "license": "MIT",
       "dependencies": {
         "@project-serum/anchor": "0.26.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uxd-protocol/uxd-client",
-  "version": "7.0.2-anchor-0.26.0",
+  "version": "7.1.0-depository-weights",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@uxd-protocol/uxd-client",
-      "version": "7.0.2-anchor-0.26.0",
+      "version": "7.1.0-depository-weights",
       "license": "MIT",
       "dependencies": {
         "@project-serum/anchor": "0.26.0",
@@ -1733,15 +1733,39 @@
         "@solana/web3.js": "^1.68.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.2.0.tgz",
+      "integrity": "sha512-gB8T4H4DEfX2IV9zGDJPOBgP1e/DbfCPDTtEqUMckpvzS1OYtva8JdFYBqMwYk7xAQ429WGF/UPqn8uQ//h2vQ==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.0.tgz",
+      "integrity": "sha512-A9983Q0LnDGdLPjxyXQ00sbV+K+O+ko2Dr+CZigbHWtX9pNfxlaBkMR8X1CztI73zuEyEBXTVjx7CE+/VSwDiQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.0.tgz",
-      "integrity": "sha512-fluIaaV+GyV24CCu/ggiHdV+j4RNh85yQnAYS/G2mZODZgGmmlrgCydjUcV3YvxCm9x8nMAfThsqTni4KiXT4A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz",
+      "integrity": "sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.4.0",
+        "espree": "^9.5.0",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -1784,9 +1808,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.35.0.tgz",
-      "integrity": "sha512-JXdzbRiWclLVoD8sNUjR443VVlYqiYmDVT6rGUEIEHU5YJW0gaVZwV2xgM7D4arkvASqD0IlLUVjHiFuxaftRw==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
+      "integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2971,14 +2995,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.53.0.tgz",
-      "integrity": "sha512-alFpFWNucPLdUOySmXCJpzr6HKC3bu7XooShWM+3w/EL6J2HIoB2PFxpLnq4JauWVk6DiVeNKzQlFEaE+X9sGw==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.54.1.tgz",
+      "integrity": "sha512-a2RQAkosH3d3ZIV08s3DcL/mcGc2M/UC528VkPULFxR9VnVPT8pBu0IyBAJJmVsCmhVfwQX1v6q+QGnmSe1bew==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.53.0",
-        "@typescript-eslint/type-utils": "5.53.0",
-        "@typescript-eslint/utils": "5.53.0",
+        "@typescript-eslint/scope-manager": "5.54.1",
+        "@typescript-eslint/type-utils": "5.54.1",
+        "@typescript-eslint/utils": "5.54.1",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
@@ -3038,14 +3062,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.53.0.tgz",
-      "integrity": "sha512-MKBw9i0DLYlmdOb3Oq/526+al20AJZpANdT6Ct9ffxcV8nKCHz63t/S0IhlTFNsBIHJv+GY5SFJ0XfqVeydQrQ==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.54.1.tgz",
+      "integrity": "sha512-8zaIXJp/nG9Ff9vQNh7TI+C3nA6q6iIsGJ4B4L6MhZ7mHnTMR4YP5vp2xydmFXIy8rpyIVbNAG44871LMt6ujg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.53.0",
-        "@typescript-eslint/types": "5.53.0",
-        "@typescript-eslint/typescript-estree": "5.53.0",
+        "@typescript-eslint/scope-manager": "5.54.1",
+        "@typescript-eslint/types": "5.54.1",
+        "@typescript-eslint/typescript-estree": "5.54.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3065,13 +3089,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.53.0.tgz",
-      "integrity": "sha512-Opy3dqNsp/9kBBeCPhkCNR7fmdSQqA+47r21hr9a14Bx0xnkElEQmhoHga+VoaoQ6uDHjDKmQPIYcUcKJifS7w==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.54.1.tgz",
+      "integrity": "sha512-zWKuGliXxvuxyM71UA/EcPxaviw39dB2504LqAmFDjmkpO8qNLHcmzlh6pbHs1h/7YQ9bnsO8CCcYCSA8sykUg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.53.0",
-        "@typescript-eslint/visitor-keys": "5.53.0"
+        "@typescript-eslint/types": "5.54.1",
+        "@typescript-eslint/visitor-keys": "5.54.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3082,13 +3106,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.53.0.tgz",
-      "integrity": "sha512-HO2hh0fmtqNLzTAme/KnND5uFNwbsdYhCZghK2SoxGp3Ifn2emv+hi0PBUjzzSh0dstUIFqOj3bp0AwQlK4OWw==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.54.1.tgz",
+      "integrity": "sha512-WREHsTz0GqVYLIbzIZYbmUUr95DKEKIXZNH57W3s+4bVnuF1TKe2jH8ZNH8rO1CeMY3U4j4UQeqPNkHMiGem3g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.53.0",
-        "@typescript-eslint/utils": "5.53.0",
+        "@typescript-eslint/typescript-estree": "5.54.1",
+        "@typescript-eslint/utils": "5.54.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -3109,9 +3133,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.53.0.tgz",
-      "integrity": "sha512-5kcDL9ZUIP756K6+QOAfPkigJmCPHcLN7Zjdz76lQWWDdzfOhZDTj1irs6gPBKiXx5/6O3L0+AvupAut3z7D2A==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.54.1.tgz",
+      "integrity": "sha512-G9+1vVazrfAfbtmCapJX8jRo2E4MDXxgm/IMOF4oGh3kq7XuK3JRkOg6y2Qu1VsTRmWETyTkWt1wxy7X7/yLkw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3122,13 +3146,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.53.0.tgz",
-      "integrity": "sha512-eKmipH7QyScpHSkhbptBBYh9v8FxtngLquq292YTEQ1pxVs39yFBlLC1xeIZcPPz1RWGqb7YgERJRGkjw8ZV7w==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.54.1.tgz",
+      "integrity": "sha512-bjK5t+S6ffHnVwA0qRPTZrxKSaFYocwFIkZx5k7pvWfsB1I57pO/0M0Skatzzw1sCkjJ83AfGTL0oFIFiDX3bg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.53.0",
-        "@typescript-eslint/visitor-keys": "5.53.0",
+        "@typescript-eslint/types": "5.54.1",
+        "@typescript-eslint/visitor-keys": "5.54.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -3182,16 +3206,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.53.0.tgz",
-      "integrity": "sha512-VUOOtPv27UNWLxFwQK/8+7kvxVC+hPHNsJjzlJyotlaHjLSIgOCKj9I0DBUjwOOA64qjBwx5afAPjksqOxMO0g==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.54.1.tgz",
+      "integrity": "sha512-IY5dyQM8XD1zfDe5X8jegX6r2EVU5o/WJnLu/znLPWCBF7KNGC+adacXnt5jEYS9JixDcoccI6CvE4RCjHMzCQ==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.53.0",
-        "@typescript-eslint/types": "5.53.0",
-        "@typescript-eslint/typescript-estree": "5.53.0",
+        "@typescript-eslint/scope-manager": "5.54.1",
+        "@typescript-eslint/types": "5.54.1",
+        "@typescript-eslint/typescript-estree": "5.54.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
@@ -3241,12 +3265,12 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.53.0.tgz",
-      "integrity": "sha512-JqNLnX3leaHFZEN0gCh81sIvgrp/2GOACZNgO4+Tkf64u51kTpAyWFOY8XHx8XuXr3N2C9zgPPHtcpMg6z1g0w==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.54.1.tgz",
+      "integrity": "sha512-q8iSoHTgwCfgcRJ2l2x+xCbu8nBlRAlsQ33k24Adj8eoVBE0f8dUeI+bAa8F84Mv05UGbAx57g2zrRsYIooqQg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.53.0",
+        "@typescript-eslint/types": "5.54.1",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -3328,12 +3352,12 @@
       }
     },
     "node_modules/agentkeepalive": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
-      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.3.0.tgz",
+      "integrity": "sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==",
       "dependencies": {
         "debug": "^4.1.0",
-        "depd": "^1.1.2",
+        "depd": "^2.0.0",
         "humanize-ms": "^1.2.1"
       },
       "engines": {
@@ -3844,9 +3868,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001458",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001458.tgz",
-      "integrity": "sha512-lQ1VlUUq5q9ro9X+5gOEyH7i3vm+AYVT1WDCVB69XOZ17KZRhnZ9J0Sqz7wTHQaLBJccNCHq8/Ww5LlOIZbB0w==",
+      "version": "1.0.30001465",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001465.tgz",
+      "integrity": "sha512-HvjgL3MYAJjceTDCcjRnQGjwUz/5qec9n7JPOzUursUoOTIsYCSDOb1l7RsnZE8mjbxG78zVRCKfrBXyvChBag==",
       "dev": true,
       "funding": [
         {
@@ -3975,9 +3999,9 @@
       "dev": true
     },
     "node_modules/core-js-compat": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.29.0.tgz",
-      "integrity": "sha512-ScMn3uZNAFhK2DGoEfErguoiAHhV2Ju+oJo/jK08p7B3f3UhocUrCCkTvnZaiS+edl5nlIoiBXKcwMc6elv4KQ==",
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.29.1.tgz",
+      "integrity": "sha512-QmchCua884D8wWskMX8tW5ydINzd8oSJVx38lx/pVkFGqztxt73GYre3pm/hyYq8bPf+MW5In4I/uRShFDsbrA==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.21.5"
@@ -4160,11 +4184,11 @@
       }
     },
     "node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/detect-newline": {
@@ -4240,9 +4264,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.311",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.311.tgz",
-      "integrity": "sha512-RoDlZufvrtr2Nx3Yx5MB8jX3aHIxm8nRWPJm3yVvyHmyKaRvn90RjzB6hNnt0AkhS3IInJdyRfQb4mWhPvUjVw==",
+      "version": "1.4.328",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.328.tgz",
+      "integrity": "sha512-DE9tTy2PNmy1v55AZAO542ui+MLC2cvINMK4P2LXGsJdput/ThVG9t+QGecPuAZZSgC8XoI+Jh9M1OG9IoNSCw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4386,13 +4410,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.35.0.tgz",
-      "integrity": "sha512-BxAf1fVL7w+JLRQhWl2pzGeSiGqbWumV4WNvc9Rhp6tiCtm4oHnyPBSEtMGZwrQgudFQ+otqzWoPB7x+hxoWsw==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
+      "integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^2.0.0",
-        "@eslint/js": "8.35.0",
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@eslint/eslintrc": "^2.0.1",
+        "@eslint/js": "8.36.0",
         "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -4403,9 +4429,8 @@
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.1.1",
-        "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.4.0",
+        "espree": "^9.5.0",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -4427,7 +4452,6 @@
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
-        "regexpp": "^3.2.0",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
@@ -4443,9 +4467,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
-      "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.7.0.tgz",
+      "integrity": "sha512-HHVXLSlVUhMSmyW4ZzEuvjpwqamgmlfkutD53cYXLikh4pt/modINRcCIApJ84czDxM4GZInwUrromsDdTImTA==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
@@ -4659,9 +4683,9 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-      "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
+      "integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.0",
@@ -4689,9 +4713,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.2.tgz",
-      "integrity": "sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -8064,9 +8088,9 @@
       }
     },
     "node_modules/regexpu-core": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.1.tgz",
-      "integrity": "sha512-nCOzW2V/X15XpLsK2rlgdwrysrBq+AauCn+omItIz4R1pIcmeot5zvjdmOBRLzEH/CkC6IxMJVmxDe3QcMuNVQ==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.2.tgz",
+      "integrity": "sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==",
       "dev": true,
       "dependencies": {
         "@babel/regjsgen": "^0.8.0",
@@ -8217,9 +8241,9 @@
       }
     },
     "node_modules/rpc-websockets/node_modules/ws": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
-      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10304,15 +10328,30 @@
         "buffer-layout": "^1.2.0"
       }
     },
+    "@eslint-community/eslint-utils": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.2.0.tgz",
+      "integrity": "sha512-gB8T4H4DEfX2IV9zGDJPOBgP1e/DbfCPDTtEqUMckpvzS1OYtva8JdFYBqMwYk7xAQ429WGF/UPqn8uQ//h2vQ==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^3.3.0"
+      }
+    },
+    "@eslint-community/regexpp": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.0.tgz",
+      "integrity": "sha512-A9983Q0LnDGdLPjxyXQ00sbV+K+O+ko2Dr+CZigbHWtX9pNfxlaBkMR8X1CztI73zuEyEBXTVjx7CE+/VSwDiQ==",
+      "dev": true
+    },
     "@eslint/eslintrc": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.0.tgz",
-      "integrity": "sha512-fluIaaV+GyV24CCu/ggiHdV+j4RNh85yQnAYS/G2mZODZgGmmlrgCydjUcV3YvxCm9x8nMAfThsqTni4KiXT4A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz",
+      "integrity": "sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.4.0",
+        "espree": "^9.5.0",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -10339,9 +10378,9 @@
       }
     },
     "@eslint/js": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.35.0.tgz",
-      "integrity": "sha512-JXdzbRiWclLVoD8sNUjR443VVlYqiYmDVT6rGUEIEHU5YJW0gaVZwV2xgM7D4arkvASqD0IlLUVjHiFuxaftRw==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
+      "integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
       "dev": true
     },
     "@humanwhocodes/config-array": {
@@ -11271,14 +11310,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.53.0.tgz",
-      "integrity": "sha512-alFpFWNucPLdUOySmXCJpzr6HKC3bu7XooShWM+3w/EL6J2HIoB2PFxpLnq4JauWVk6DiVeNKzQlFEaE+X9sGw==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.54.1.tgz",
+      "integrity": "sha512-a2RQAkosH3d3ZIV08s3DcL/mcGc2M/UC528VkPULFxR9VnVPT8pBu0IyBAJJmVsCmhVfwQX1v6q+QGnmSe1bew==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.53.0",
-        "@typescript-eslint/type-utils": "5.53.0",
-        "@typescript-eslint/utils": "5.53.0",
+        "@typescript-eslint/scope-manager": "5.54.1",
+        "@typescript-eslint/type-utils": "5.54.1",
+        "@typescript-eslint/utils": "5.54.1",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
@@ -11315,53 +11354,53 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.53.0.tgz",
-      "integrity": "sha512-MKBw9i0DLYlmdOb3Oq/526+al20AJZpANdT6Ct9ffxcV8nKCHz63t/S0IhlTFNsBIHJv+GY5SFJ0XfqVeydQrQ==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.54.1.tgz",
+      "integrity": "sha512-8zaIXJp/nG9Ff9vQNh7TI+C3nA6q6iIsGJ4B4L6MhZ7mHnTMR4YP5vp2xydmFXIy8rpyIVbNAG44871LMt6ujg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.53.0",
-        "@typescript-eslint/types": "5.53.0",
-        "@typescript-eslint/typescript-estree": "5.53.0",
+        "@typescript-eslint/scope-manager": "5.54.1",
+        "@typescript-eslint/types": "5.54.1",
+        "@typescript-eslint/typescript-estree": "5.54.1",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.53.0.tgz",
-      "integrity": "sha512-Opy3dqNsp/9kBBeCPhkCNR7fmdSQqA+47r21hr9a14Bx0xnkElEQmhoHga+VoaoQ6uDHjDKmQPIYcUcKJifS7w==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.54.1.tgz",
+      "integrity": "sha512-zWKuGliXxvuxyM71UA/EcPxaviw39dB2504LqAmFDjmkpO8qNLHcmzlh6pbHs1h/7YQ9bnsO8CCcYCSA8sykUg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.53.0",
-        "@typescript-eslint/visitor-keys": "5.53.0"
+        "@typescript-eslint/types": "5.54.1",
+        "@typescript-eslint/visitor-keys": "5.54.1"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.53.0.tgz",
-      "integrity": "sha512-HO2hh0fmtqNLzTAme/KnND5uFNwbsdYhCZghK2SoxGp3Ifn2emv+hi0PBUjzzSh0dstUIFqOj3bp0AwQlK4OWw==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.54.1.tgz",
+      "integrity": "sha512-WREHsTz0GqVYLIbzIZYbmUUr95DKEKIXZNH57W3s+4bVnuF1TKe2jH8ZNH8rO1CeMY3U4j4UQeqPNkHMiGem3g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.53.0",
-        "@typescript-eslint/utils": "5.53.0",
+        "@typescript-eslint/typescript-estree": "5.54.1",
+        "@typescript-eslint/utils": "5.54.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.53.0.tgz",
-      "integrity": "sha512-5kcDL9ZUIP756K6+QOAfPkigJmCPHcLN7Zjdz76lQWWDdzfOhZDTj1irs6gPBKiXx5/6O3L0+AvupAut3z7D2A==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.54.1.tgz",
+      "integrity": "sha512-G9+1vVazrfAfbtmCapJX8jRo2E4MDXxgm/IMOF4oGh3kq7XuK3JRkOg6y2Qu1VsTRmWETyTkWt1wxy7X7/yLkw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.53.0.tgz",
-      "integrity": "sha512-eKmipH7QyScpHSkhbptBBYh9v8FxtngLquq292YTEQ1pxVs39yFBlLC1xeIZcPPz1RWGqb7YgERJRGkjw8ZV7w==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.54.1.tgz",
+      "integrity": "sha512-bjK5t+S6ffHnVwA0qRPTZrxKSaFYocwFIkZx5k7pvWfsB1I57pO/0M0Skatzzw1sCkjJ83AfGTL0oFIFiDX3bg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.53.0",
-        "@typescript-eslint/visitor-keys": "5.53.0",
+        "@typescript-eslint/types": "5.54.1",
+        "@typescript-eslint/visitor-keys": "5.54.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -11396,16 +11435,16 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.53.0.tgz",
-      "integrity": "sha512-VUOOtPv27UNWLxFwQK/8+7kvxVC+hPHNsJjzlJyotlaHjLSIgOCKj9I0DBUjwOOA64qjBwx5afAPjksqOxMO0g==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.54.1.tgz",
+      "integrity": "sha512-IY5dyQM8XD1zfDe5X8jegX6r2EVU5o/WJnLu/znLPWCBF7KNGC+adacXnt5jEYS9JixDcoccI6CvE4RCjHMzCQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.53.0",
-        "@typescript-eslint/types": "5.53.0",
-        "@typescript-eslint/typescript-estree": "5.53.0",
+        "@typescript-eslint/scope-manager": "5.54.1",
+        "@typescript-eslint/types": "5.54.1",
+        "@typescript-eslint/typescript-estree": "5.54.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
@@ -11438,12 +11477,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.53.0.tgz",
-      "integrity": "sha512-JqNLnX3leaHFZEN0gCh81sIvgrp/2GOACZNgO4+Tkf64u51kTpAyWFOY8XHx8XuXr3N2C9zgPPHtcpMg6z1g0w==",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.54.1.tgz",
+      "integrity": "sha512-q8iSoHTgwCfgcRJ2l2x+xCbu8nBlRAlsQ33k24Adj8eoVBE0f8dUeI+bAa8F84Mv05UGbAx57g2zrRsYIooqQg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.53.0",
+        "@typescript-eslint/types": "5.54.1",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -11500,12 +11539,12 @@
       }
     },
     "agentkeepalive": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
-      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.3.0.tgz",
+      "integrity": "sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==",
       "requires": {
         "debug": "^4.1.0",
-        "depd": "^1.1.2",
+        "depd": "^2.0.0",
         "humanize-ms": "^1.2.1"
       }
     },
@@ -11875,9 +11914,9 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001458",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001458.tgz",
-      "integrity": "sha512-lQ1VlUUq5q9ro9X+5gOEyH7i3vm+AYVT1WDCVB69XOZ17KZRhnZ9J0Sqz7wTHQaLBJccNCHq8/Ww5LlOIZbB0w==",
+      "version": "1.0.30001465",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001465.tgz",
+      "integrity": "sha512-HvjgL3MYAJjceTDCcjRnQGjwUz/5qec9n7JPOzUursUoOTIsYCSDOb1l7RsnZE8mjbxG78zVRCKfrBXyvChBag==",
       "dev": true
     },
     "chalk": {
@@ -11974,9 +12013,9 @@
       "dev": true
     },
     "core-js-compat": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.29.0.tgz",
-      "integrity": "sha512-ScMn3uZNAFhK2DGoEfErguoiAHhV2Ju+oJo/jK08p7B3f3UhocUrCCkTvnZaiS+edl5nlIoiBXKcwMc6elv4KQ==",
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.29.1.tgz",
+      "integrity": "sha512-QmchCua884D8wWskMX8tW5ydINzd8oSJVx38lx/pVkFGqztxt73GYre3pm/hyYq8bPf+MW5In4I/uRShFDsbrA==",
       "dev": true,
       "requires": {
         "browserslist": "^4.21.5"
@@ -12113,9 +12152,9 @@
       "dev": true
     },
     "depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -12174,9 +12213,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.311",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.311.tgz",
-      "integrity": "sha512-RoDlZufvrtr2Nx3Yx5MB8jX3aHIxm8nRWPJm3yVvyHmyKaRvn90RjzB6hNnt0AkhS3IInJdyRfQb4mWhPvUjVw==",
+      "version": "1.4.328",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.328.tgz",
+      "integrity": "sha512-DE9tTy2PNmy1v55AZAO542ui+MLC2cvINMK4P2LXGsJdput/ThVG9t+QGecPuAZZSgC8XoI+Jh9M1OG9IoNSCw==",
       "dev": true
     },
     "emittery": {
@@ -12286,13 +12325,15 @@
       }
     },
     "eslint": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.35.0.tgz",
-      "integrity": "sha512-BxAf1fVL7w+JLRQhWl2pzGeSiGqbWumV4WNvc9Rhp6tiCtm4oHnyPBSEtMGZwrQgudFQ+otqzWoPB7x+hxoWsw==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
+      "integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^2.0.0",
-        "@eslint/js": "8.35.0",
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@eslint/eslintrc": "^2.0.1",
+        "@eslint/js": "8.36.0",
         "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -12303,9 +12344,8 @@
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.1.1",
-        "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.4.0",
+        "espree": "^9.5.0",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -12327,7 +12367,6 @@
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
-        "regexpp": "^3.2.0",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
@@ -12422,9 +12461,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
-      "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.7.0.tgz",
+      "integrity": "sha512-HHVXLSlVUhMSmyW4ZzEuvjpwqamgmlfkutD53cYXLikh4pt/modINRcCIApJ84czDxM4GZInwUrromsDdTImTA==",
       "dev": true,
       "requires": {}
     },
@@ -12471,9 +12510,9 @@
       "dev": true
     },
     "espree": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
-      "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
+      "integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
       "dev": true,
       "requires": {
         "acorn": "^8.8.0",
@@ -12488,9 +12527,9 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.2.tgz",
-      "integrity": "sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
@@ -15015,9 +15054,9 @@
       "dev": true
     },
     "regexpu-core": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.1.tgz",
-      "integrity": "sha512-nCOzW2V/X15XpLsK2rlgdwrysrBq+AauCn+omItIz4R1pIcmeot5zvjdmOBRLzEH/CkC6IxMJVmxDe3QcMuNVQ==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.2.tgz",
+      "integrity": "sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==",
       "dev": true,
       "requires": {
         "@babel/regjsgen": "^0.8.0",
@@ -15126,9 +15165,9 @@
       },
       "dependencies": {
         "ws": {
-          "version": "8.12.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
-          "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
+          "version": "8.13.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
           "requires": {}
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxd-protocol/uxd-client",
-  "version": "7.1.0-depository-weights",
+  "version": "7.1.1-depository-weights",
   "description": "JavaScript Client for the UXD Solana Program",
   "keywords": [
     "solana",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxd-protocol/uxd-client",
-  "version": "7.0.2-anchor-0.26.0",
+  "version": "7.1.0-depository-weights",
   "description": "JavaScript Client for the UXD Solana Program",
   "keywords": [
     "solana",

--- a/src/client.ts
+++ b/src/client.ts
@@ -339,6 +339,7 @@ export class UXDClient {
       redeemingFeeInBps?: number;
       mintingDisabled?: boolean;
       profitsBeneficiaryCollateral?: PublicKey;
+      redeemableAmountUnderManagementWeight?: number;
     },
     options: ConfirmOptions
   ): TransactionInstruction {
@@ -348,6 +349,7 @@ export class UXDClient {
       redeemingFeeInBps,
       mintingDisabled,
       profitsBeneficiaryCollateral,
+      redeemableAmountUnderManagementWeight,
     } = uiFields;
     const fields = {
       redeemableAmountUnderManagementCap:
@@ -366,6 +368,10 @@ export class UXDClient {
       profitsBeneficiaryCollateral:
         typeof profitsBeneficiaryCollateral !== 'undefined'
           ? profitsBeneficiaryCollateral
+          : null,
+      redeemableAmountUnderManagementWeight:
+        typeof redeemableAmountUnderManagementWeight !== 'undefined'
+          ? redeemableAmountUnderManagementWeight
           : null,
     };
     return this.instruction.editMercurialVaultDepository(fields, {
@@ -441,6 +447,7 @@ export class UXDClient {
       redeemingFeeInBps?: number;
       mintingDisabled?: boolean;
       profitsBeneficiaryCollateral?: PublicKey;
+      redeemableAmountUnderManagementWeight?: number;
     },
     options: ConfirmOptions
   ): TransactionInstruction {
@@ -450,6 +457,7 @@ export class UXDClient {
       redeemingFeeInBps,
       mintingDisabled,
       profitsBeneficiaryCollateral,
+      redeemableAmountUnderManagementWeight,
     } = uiFields;
     const fields = {
       redeemableAmountUnderManagementCap:
@@ -466,6 +474,10 @@ export class UXDClient {
       profitsBeneficiaryCollateral:
         profitsBeneficiaryCollateral !== undefined
           ? profitsBeneficiaryCollateral
+          : null,
+      redeemableAmountUnderManagementWeight:
+        redeemableAmountUnderManagementWeight !== undefined
+          ? redeemableAmountUnderManagementWeight
           : null,
     };
     return this.instruction.editCredixLpDepository(fields, {

--- a/src/client.ts
+++ b/src/client.ts
@@ -339,7 +339,7 @@ export class UXDClient {
       redeemingFeeInBps?: number;
       mintingDisabled?: boolean;
       profitsBeneficiaryCollateral?: PublicKey;
-      redeemableAmountUnderManagementWeight?: number;
+      redeemableAmountUnderManagementWeightBps?: number;
     },
     options: ConfirmOptions
   ): TransactionInstruction {
@@ -349,7 +349,7 @@ export class UXDClient {
       redeemingFeeInBps,
       mintingDisabled,
       profitsBeneficiaryCollateral,
-      redeemableAmountUnderManagementWeight,
+      redeemableAmountUnderManagementWeightBps,
     } = uiFields;
     const fields = {
       redeemableAmountUnderManagementCap:
@@ -369,9 +369,9 @@ export class UXDClient {
         typeof profitsBeneficiaryCollateral !== 'undefined'
           ? profitsBeneficiaryCollateral
           : null,
-      redeemableAmountUnderManagementWeight:
-        typeof redeemableAmountUnderManagementWeight !== 'undefined'
-          ? redeemableAmountUnderManagementWeight
+      redeemableAmountUnderManagementWeightBps:
+        typeof redeemableAmountUnderManagementWeightBps !== 'undefined'
+          ? redeemableAmountUnderManagementWeightBps
           : null,
     };
     return this.instruction.editMercurialVaultDepository(fields, {
@@ -447,7 +447,7 @@ export class UXDClient {
       redeemingFeeInBps?: number;
       mintingDisabled?: boolean;
       profitsBeneficiaryCollateral?: PublicKey;
-      redeemableAmountUnderManagementWeight?: number;
+      redeemableAmountUnderManagementWeightBps?: number;
     },
     options: ConfirmOptions
   ): TransactionInstruction {
@@ -457,7 +457,7 @@ export class UXDClient {
       redeemingFeeInBps,
       mintingDisabled,
       profitsBeneficiaryCollateral,
-      redeemableAmountUnderManagementWeight,
+      redeemableAmountUnderManagementWeightBps,
     } = uiFields;
     const fields = {
       redeemableAmountUnderManagementCap:
@@ -475,9 +475,9 @@ export class UXDClient {
         profitsBeneficiaryCollateral !== undefined
           ? profitsBeneficiaryCollateral
           : null,
-      redeemableAmountUnderManagementWeight:
-        redeemableAmountUnderManagementWeight !== undefined
-          ? redeemableAmountUnderManagementWeight
+      redeemableAmountUnderManagementWeightBps:
+        redeemableAmountUnderManagementWeightBps !== undefined
+          ? redeemableAmountUnderManagementWeightBps
           : null,
     };
     return this.instruction.editCredixLpDepository(fields, {

--- a/src/idl.ts
+++ b/src/idl.ts
@@ -1,5 +1,5 @@
 export type Uxd = {
-  version: '7.1.0';
+  version: '7.1.1';
   name: 'uxd';
   instructions: [
     {
@@ -1625,17 +1625,17 @@ export type Uxd = {
             type: 'publicKey';
           },
           {
-            name: 'redeemableAmountUnderManagementWeight';
-            type: 'u32';
+            name: 'redeemableAmountUnderManagementWeightBps';
+            type: 'u16';
           },
           {
-            name: 'redeemableAmountUnderManagementTarget';
+            name: 'redeemableAmountUnderManagementTargetAmount';
             type: 'u64';
           },
           {
             name: 'reserved';
             type: {
-              array: ['u8', 756];
+              array: ['u8', 758];
             };
           }
         ];
@@ -1797,17 +1797,17 @@ export type Uxd = {
             type: 'publicKey';
           },
           {
-            name: 'redeemableAmountUnderManagementWeight';
-            type: 'u32';
+            name: 'redeemableAmountUnderManagementWeightBps';
+            type: 'u16';
           },
           {
-            name: 'redeemableAmountUnderManagementTarget';
+            name: 'redeemableAmountUnderManagementTargetAmount';
             type: 'u64';
           },
           {
             name: 'reserved';
             type: {
-              array: ['u8', 576];
+              array: ['u8', 578];
             };
           }
         ];
@@ -1851,9 +1851,9 @@ export type Uxd = {
             };
           },
           {
-            name: 'redeemableAmountUnderManagementWeight';
+            name: 'redeemableAmountUnderManagementWeightBps';
             type: {
-              option: 'u32';
+              option: 'u16';
             };
           }
         ];
@@ -1929,9 +1929,9 @@ export type Uxd = {
             };
           },
           {
-            name: 'redeemableAmountUnderManagementWeight';
+            name: 'redeemableAmountUnderManagementWeightBps';
             type: {
-              option: 'u32';
+              option: 'u16';
             };
           }
         ];
@@ -2145,7 +2145,7 @@ export type Uxd = {
       ];
     },
     {
-      name: 'SetDepositoryRedeemableAmountUnderManagementWeightEvent';
+      name: 'SetDepositoryRedeemableAmountUnderManagementWeightBpsEvent';
       fields: [
         {
           name: 'version';
@@ -2163,8 +2163,8 @@ export type Uxd = {
           index: true;
         },
         {
-          name: 'redeemableAmountUnderManagementWeight';
-          type: 'u32';
+          name: 'redeemableAmountUnderManagementWeightBps';
+          type: 'u16';
           index: true;
         }
       ];
@@ -2720,7 +2720,7 @@ export type Uxd = {
 };
 
 export const IDL: Uxd = {
-  version: '7.1.0',
+  version: '7.1.1',
   name: 'uxd',
   instructions: [
     {
@@ -4346,17 +4346,17 @@ export const IDL: Uxd = {
             type: 'publicKey',
           },
           {
-            name: 'redeemableAmountUnderManagementWeight',
-            type: 'u32',
+            name: 'redeemableAmountUnderManagementWeightBps',
+            type: 'u16',
           },
           {
-            name: 'redeemableAmountUnderManagementTarget',
+            name: 'redeemableAmountUnderManagementTargetAmount',
             type: 'u64',
           },
           {
             name: 'reserved',
             type: {
-              array: ['u8', 756],
+              array: ['u8', 758],
             },
           },
         ],
@@ -4518,17 +4518,17 @@ export const IDL: Uxd = {
             type: 'publicKey',
           },
           {
-            name: 'redeemableAmountUnderManagementWeight',
-            type: 'u32',
+            name: 'redeemableAmountUnderManagementWeightBps',
+            type: 'u16',
           },
           {
-            name: 'redeemableAmountUnderManagementTarget',
+            name: 'redeemableAmountUnderManagementTargetAmount',
             type: 'u64',
           },
           {
             name: 'reserved',
             type: {
-              array: ['u8', 576],
+              array: ['u8', 578],
             },
           },
         ],
@@ -4572,9 +4572,9 @@ export const IDL: Uxd = {
             },
           },
           {
-            name: 'redeemableAmountUnderManagementWeight',
+            name: 'redeemableAmountUnderManagementWeightBps',
             type: {
-              option: 'u32',
+              option: 'u16',
             },
           },
         ],
@@ -4650,9 +4650,9 @@ export const IDL: Uxd = {
             },
           },
           {
-            name: 'redeemableAmountUnderManagementWeight',
+            name: 'redeemableAmountUnderManagementWeightBps',
             type: {
-              option: 'u32',
+              option: 'u16',
             },
           },
         ],
@@ -4866,7 +4866,7 @@ export const IDL: Uxd = {
       ],
     },
     {
-      name: 'SetDepositoryRedeemableAmountUnderManagementWeightEvent',
+      name: 'SetDepositoryRedeemableAmountUnderManagementWeightBpsEvent',
       fields: [
         {
           name: 'version',
@@ -4884,8 +4884,8 @@ export const IDL: Uxd = {
           index: true,
         },
         {
-          name: 'redeemableAmountUnderManagementWeight',
-          type: 'u32',
+          name: 'redeemableAmountUnderManagementWeightBps',
+          type: 'u16',
           index: true,
         },
       ],

--- a/src/idl.ts
+++ b/src/idl.ts
@@ -1,5 +1,5 @@
 export type Uxd = {
-  version: '7.0.0';
+  version: '7.1.0';
   name: 'uxd';
   instructions: [
     {
@@ -214,6 +214,38 @@ export type Uxd = {
           };
         }
       ];
+    },
+    {
+      name: 'computeDepositoriesTargets';
+      accounts: [
+        {
+          name: 'payer';
+          isMut: true;
+          isSigner: true;
+          docs: ['#1 Permissionless IX that can be called by anyone'];
+        },
+        {
+          name: 'controller';
+          isMut: true;
+          isSigner: false;
+          docs: [
+            '#2 The top level UXDProgram on chain account managing the redeemable mint'
+          ];
+        },
+        {
+          name: 'mercurialVaultDepository';
+          isMut: true;
+          isSigner: false;
+          docs: ['#3 The first known active mercurial vault depository'];
+        },
+        {
+          name: 'credixLpDepository';
+          isMut: true;
+          isSigner: false;
+          docs: ['#4 The first known active credix lp depository'];
+        }
+      ];
+      args: [];
     },
     {
       name: 'mintWithMercurialVaultDepository';
@@ -1493,6 +1525,12 @@ export type Uxd = {
           {
             name: 'profitsTotalCollected';
             type: 'u128';
+          },
+          {
+            name: 'reserved';
+            type: {
+              array: ['u8', 230];
+            };
           }
         ];
       };
@@ -1585,6 +1623,20 @@ export type Uxd = {
           {
             name: 'profitsBeneficiaryCollateral';
             type: 'publicKey';
+          },
+          {
+            name: 'redeemableAmountUnderManagementWeight';
+            type: 'u32';
+          },
+          {
+            name: 'redeemableAmountUnderManagementTarget';
+            type: 'u64';
+          },
+          {
+            name: 'reserved';
+            type: {
+              array: ['u8', 756];
+            };
           }
         ];
       };
@@ -1645,6 +1697,12 @@ export type Uxd = {
           {
             name: 'mangoCollateralReinjectedEth';
             type: 'bool';
+          },
+          {
+            name: 'reserved';
+            type: {
+              array: ['u8', 512];
+            };
           }
         ];
       };
@@ -1737,6 +1795,20 @@ export type Uxd = {
           {
             name: 'profitsBeneficiaryCollateral';
             type: 'publicKey';
+          },
+          {
+            name: 'redeemableAmountUnderManagementWeight';
+            type: 'u32';
+          },
+          {
+            name: 'redeemableAmountUnderManagementTarget';
+            type: 'u64';
+          },
+          {
+            name: 'reserved';
+            type: {
+              array: ['u8', 576];
+            };
           }
         ];
       };
@@ -1776,6 +1848,12 @@ export type Uxd = {
             name: 'profitsBeneficiaryCollateral';
             type: {
               option: 'publicKey';
+            };
+          },
+          {
+            name: 'redeemableAmountUnderManagementWeight';
+            type: {
+              option: 'u32';
             };
           }
         ];
@@ -1848,6 +1926,12 @@ export type Uxd = {
             name: 'profitsBeneficiaryCollateral';
             type: {
               option: 'publicKey';
+            };
+          },
+          {
+            name: 'redeemableAmountUnderManagementWeight';
+            type: {
+              option: 'u32';
             };
           }
         ];
@@ -2056,6 +2140,31 @@ export type Uxd = {
         {
           name: 'profitsBeneficiaryCollateral';
           type: 'publicKey';
+          index: true;
+        }
+      ];
+    },
+    {
+      name: 'SetDepositoryRedeemableAmountUnderManagementWeightEvent';
+      fields: [
+        {
+          name: 'version';
+          type: 'u8';
+          index: true;
+        },
+        {
+          name: 'controller';
+          type: 'publicKey';
+          index: true;
+        },
+        {
+          name: 'depository';
+          type: 'publicKey';
+          index: true;
+        },
+        {
+          name: 'redeemableAmountUnderManagementWeight';
+          type: 'u32';
           index: true;
         }
       ];
@@ -2611,7 +2720,7 @@ export type Uxd = {
 };
 
 export const IDL: Uxd = {
-  version: '7.0.0',
+  version: '7.1.0',
   name: 'uxd',
   instructions: [
     {
@@ -2826,6 +2935,38 @@ export const IDL: Uxd = {
           },
         },
       ],
+    },
+    {
+      name: 'computeDepositoriesTargets',
+      accounts: [
+        {
+          name: 'payer',
+          isMut: true,
+          isSigner: true,
+          docs: ['#1 Permissionless IX that can be called by anyone'],
+        },
+        {
+          name: 'controller',
+          isMut: true,
+          isSigner: false,
+          docs: [
+            '#2 The top level UXDProgram on chain account managing the redeemable mint',
+          ],
+        },
+        {
+          name: 'mercurialVaultDepository',
+          isMut: true,
+          isSigner: false,
+          docs: ['#3 The first known active mercurial vault depository'],
+        },
+        {
+          name: 'credixLpDepository',
+          isMut: true,
+          isSigner: false,
+          docs: ['#4 The first known active credix lp depository'],
+        },
+      ],
+      args: [],
     },
     {
       name: 'mintWithMercurialVaultDepository',
@@ -4106,6 +4247,12 @@ export const IDL: Uxd = {
             name: 'profitsTotalCollected',
             type: 'u128',
           },
+          {
+            name: 'reserved',
+            type: {
+              array: ['u8', 230],
+            },
+          },
         ],
       },
     },
@@ -4198,6 +4345,20 @@ export const IDL: Uxd = {
             name: 'profitsBeneficiaryCollateral',
             type: 'publicKey',
           },
+          {
+            name: 'redeemableAmountUnderManagementWeight',
+            type: 'u32',
+          },
+          {
+            name: 'redeemableAmountUnderManagementTarget',
+            type: 'u64',
+          },
+          {
+            name: 'reserved',
+            type: {
+              array: ['u8', 756],
+            },
+          },
         ],
       },
     },
@@ -4257,6 +4418,12 @@ export const IDL: Uxd = {
           {
             name: 'mangoCollateralReinjectedEth',
             type: 'bool',
+          },
+          {
+            name: 'reserved',
+            type: {
+              array: ['u8', 512],
+            },
           },
         ],
       },
@@ -4350,6 +4517,20 @@ export const IDL: Uxd = {
             name: 'profitsBeneficiaryCollateral',
             type: 'publicKey',
           },
+          {
+            name: 'redeemableAmountUnderManagementWeight',
+            type: 'u32',
+          },
+          {
+            name: 'redeemableAmountUnderManagementTarget',
+            type: 'u64',
+          },
+          {
+            name: 'reserved',
+            type: {
+              array: ['u8', 576],
+            },
+          },
         ],
       },
     },
@@ -4388,6 +4569,12 @@ export const IDL: Uxd = {
             name: 'profitsBeneficiaryCollateral',
             type: {
               option: 'publicKey',
+            },
+          },
+          {
+            name: 'redeemableAmountUnderManagementWeight',
+            type: {
+              option: 'u32',
             },
           },
         ],
@@ -4460,6 +4647,12 @@ export const IDL: Uxd = {
             name: 'profitsBeneficiaryCollateral',
             type: {
               option: 'publicKey',
+            },
+          },
+          {
+            name: 'redeemableAmountUnderManagementWeight',
+            type: {
+              option: 'u32',
             },
           },
         ],
@@ -4668,6 +4861,31 @@ export const IDL: Uxd = {
         {
           name: 'profitsBeneficiaryCollateral',
           type: 'publicKey',
+          index: true,
+        },
+      ],
+    },
+    {
+      name: 'SetDepositoryRedeemableAmountUnderManagementWeightEvent',
+      fields: [
+        {
+          name: 'version',
+          type: 'u8',
+          index: true,
+        },
+        {
+          name: 'controller',
+          type: 'publicKey',
+          index: true,
+        },
+        {
+          name: 'depository',
+          type: 'publicKey',
+          index: true,
+        },
+        {
+          name: 'redeemableAmountUnderManagementWeight',
+          type: 'u32',
           index: true,
         },
       ],

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -37,6 +37,8 @@ export class MercurialVaultDepositoryAccount {
   profitsTotalCollected!: BN; // u128
   lastProfitsCollectionUnixTimestamp!: BN; // u64
   profitsBeneficiaryCollateral!: PublicKey;
+  redeemableAmountUnderManagementWeight!: number; // u32
+  redeemableAmountUnderManagementTarget!: BN; // u64
 }
 
 // V1
@@ -76,4 +78,6 @@ export class CredixLpDepositoryAccount {
   redeemingFeeTotalAccrued!: BN; // u128
   profitsTotalCollected!: BN; // u128
   profitsBeneficiaryCollateral!: PublicKey;
+  redeemableAmountUnderManagementWeight!: number; // u32
+  redeemableAmountUnderManagementTarget!: BN; // u64
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -37,8 +37,8 @@ export class MercurialVaultDepositoryAccount {
   profitsTotalCollected!: BN; // u128
   lastProfitsCollectionUnixTimestamp!: BN; // u64
   profitsBeneficiaryCollateral!: PublicKey;
-  redeemableAmountUnderManagementWeight!: number; // u32
-  redeemableAmountUnderManagementTarget!: BN; // u64
+  redeemableAmountUnderManagementWeightBps!: number; // u16
+  redeemableAmountUnderManagementTargetAmount!: BN; // u64
 }
 
 // V1
@@ -78,6 +78,6 @@ export class CredixLpDepositoryAccount {
   redeemingFeeTotalAccrued!: BN; // u128
   profitsTotalCollected!: BN; // u128
   profitsBeneficiaryCollateral!: PublicKey;
-  redeemableAmountUnderManagementWeight!: number; // u32
-  redeemableAmountUnderManagementTarget!: BN; // u64
+  redeemableAmountUnderManagementWeightBps!: number; // u16
+  redeemableAmountUnderManagementTargetAmount!: BN; // u64
 }


### PR DESCRIPTION
PR Combo:
- uxd-client: https://github.com/UXDProtocol/uxd-client/pull/40
- uxd-program: https://github.com/UXDProtocol/uxd-program/pull/241

This PR introduces:
-  a new IX: `compute_depositories_targets`
- 2 new fields for credix/mercurial depositories:
   - `redeemable_amount_under_management_weight` // manual static arbitrary weight desired for the depository
   - `redeemable_amount_under_management_target` // absolute amount depending on the weight, cap and total supply

The goal of this new `compute_depositories_targets` IX the following:
- uses all depositories `redeemable_amount_under_management_weight`
- uses the current total supply and all depositories caps
- then compute the new absolute `redeemable_amount_under_management_target` for all depositories

The idea is that the amount in `redeemable_amount_under_management_target` of each depositories will then be used as an informatory value used during computing rebalancing amounts later (this amount can fluctuate over time, rebalancing can be lagging a bit in time without any problem)